### PR TITLE
removed leakless=false

### DIFF
--- a/rod.go
+++ b/rod.go
@@ -15,9 +15,6 @@ func launchInLambda() *launcher.Launcher {
 		// where lambda runtime stores chromium
 		Bin("/opt/chromium").
 
-		// no need to use leakless on aws-lambda, lambda will ensure no process leak
-		Leakless(false).
-
 		// recommended flags to run in serverless environments
 		// see https://github.com/alixaxel/chrome-aws-lambda/blob/master/source/index.ts
 		Set("allow-running-insecure-content").


### PR DESCRIPTION
Turning off chromium's leakless was causing lambda to fail when invoking the function hundreds of times in a row.

cc @ysmood 