### PR TITLE
Fix to memory build up when lambda warm starts

### DIFF
--- a/rod.go
+++ b/rod.go
@@ -15,9 +15,6 @@ func launchInLambda() *launcher.Launcher {
 		// where lambda runtime stores chromium
 		Bin("/opt/chromium").
 
-		// no need to use leakless on aws-lambda, lambda will ensure no process leak
-		Leakless(true).
-
 		// recommended flags to run in serverless environments
 		// see https://github.com/alixaxel/chrome-aws-lambda/blob/master/source/index.ts
 		Set("allow-running-insecure-content").

--- a/template.yaml
+++ b/template.yaml
@@ -11,6 +11,8 @@ Resources:
         - x86_64
       MemorySize: 1200
       Timeout: 10
+      EphemeralStorage:
+        Size: 10240
       Events: # https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-property-function-api.html
         GetPageHTML:
           Type: Api

--- a/template.yaml
+++ b/template.yaml
@@ -11,8 +11,6 @@ Resources:
         - x86_64
       MemorySize: 1200
       Timeout: 10
-      EphemeralStorage:
-        Size: 10240
       Events: # https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-property-function-api.html
         GetPageHTML:
           Type: Api


### PR DESCRIPTION
Rod begins to fail after back to back invocations. I assume this has to do with [how lambda warm starts](https://aws.amazon.com/blogs/compute/operating-lambda-performance-optimization-part-1/#:~:text=During%20this%20time%2C%20if%20another,called%20a%20%E2%80%9Cwarm%20start%E2%80%9D.), in that it reuses the environment spin up for a previous call.